### PR TITLE
Change to use encoder offset; fix other oddities possibly affecting odometry

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -69,10 +69,10 @@ public class Constants {
         public static final int RearRightDriveID   = 10, RearRightSteerID   = 11, RearRightEncoderID = 12;
 
         SwerveModule[] moduleArray = new SwerveModule[] {
-            new SwerveModule(FrontRightDriveID,FrontRightSteerID,FrontRightEncoderID, true),
-            new SwerveModule(FrontLeftDriveID, FrontLeftSteerID, FrontLeftEncoderID, false),
-            new SwerveModule(RearLeftDriveID, RearLeftSteerID, RearLeftEncoderID, false),
-            new SwerveModule(RearRightDriveID, RearRightSteerID, RearRightEncoderID, true)
+            new SwerveModule(FrontRightDriveID,FrontRightSteerID,FrontRightEncoderID),
+            new SwerveModule(FrontLeftDriveID, FrontLeftSteerID, FrontLeftEncoderID),
+            new SwerveModule(RearLeftDriveID, RearLeftSteerID, RearLeftEncoderID),
+            new SwerveModule(RearRightDriveID, RearRightSteerID, RearRightEncoderID)
         };
 
         public static final double TranslationPow = 3;

--- a/src/main/java/frc/robot/Subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveModule.java
@@ -3,6 +3,7 @@ package frc.robot.Subsystems;
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
@@ -41,7 +42,7 @@ public class SwerveModule extends SubsystemBase{
     final double STEER_VELOCITY_CONVERSION = STEER_POSITION_CONVERSION / 60.0;
     private final SlewRateLimiter steerLimiter = new SlewRateLimiter(Constants.Drivetrain.SteerMotorSlewRate);
 
-    public SwerveModule(int driveMotorID, int steerMotorID, int encoderID, boolean invertDirection){
+    public SwerveModule(int driveMotorID, int steerMotorID, int encoderID){
         this.driveMotorID = driveMotorID;
         this.encoderID = encoderID;
 
@@ -52,9 +53,6 @@ public class SwerveModule extends SubsystemBase{
         driveMotorConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
         driveMotorConfig.CurrentLimits.SupplyCurrentLimit = 40;
         driveMotorConfig.Feedback.SensorToMechanismRatio = 1/DRIVE_POSITION_CONVERSION;
-        if (invertDirection) {
-            driveMotorConfig.MotorOutput.Inverted = InvertedValue.Clockwise_Positive;
-        }
         driveMotor.getConfigurator().apply(driveMotorConfig);
         driveMotor.setPosition(0);
 
@@ -68,6 +66,10 @@ public class SwerveModule extends SubsystemBase{
         
         // module encoder
         moduleEncoder = new CANcoder(encoderID, new CANBus("*"));
+        var steerEncoderConfig = new CANcoderConfiguration();
+        steerEncoderConfig.MagnetSensor.MagnetOffset = -Preferences.getDouble(EncoderPreferenceKey + encoderID, 0);
+        steerEncoderConfig.MagnetSensor.AbsoluteSensorDiscontinuityPoint = 0.5;
+        moduleEncoder.getConfigurator().apply(steerEncoderConfig);
 
         //controllers
         //driveController = driveMotor.getPIDController();
@@ -76,7 +78,7 @@ public class SwerveModule extends SubsystemBase{
         //driveController.setD(Constants.Modules.SpeedKD);
 
         steerController = new PIDController(Constants.Drivetrain.SteerDriveKP, Constants.Drivetrain.SteerDriveKI, Constants.Drivetrain.SteerDriveKD);
-        steerController.enableContinuousInput(0 - Preferences.getDouble(EncoderPreferenceKey + encoderID, 0), 1 - Preferences.getDouble(EncoderPreferenceKey + encoderID, 0));
+        steerController.enableContinuousInput(-0.5, 0.5);
 
     }
 
@@ -86,6 +88,7 @@ public class SwerveModule extends SubsystemBase{
         //driveController.setReference(targetState.speedMetersPerSecond / DRIVE_VELOCITY_CONVERSION, ControlType.kVelocity);
 
         double currentAngle = getModuleAngRotations();
+        // TODO: steer PID on motor controller with external cancoder sensor
         double steerMotorCommand = steerController.calculate(currentAngle, targetState.angle.getRotations());
         steerMotor.set(steerLimiter.calculate(steerMotorCommand));
         // Cosine compensation: drive wheel slower when it's not rotated to the correct position yet
@@ -96,6 +99,9 @@ public class SwerveModule extends SubsystemBase{
     public Command calibrate() {
         return runOnce(() -> {
             var encoderValue = moduleEncoder.getAbsolutePosition().getValueAsDouble();
+            var steerEncoderConfig = new CANcoderConfiguration();
+            steerEncoderConfig.MagnetSensor.MagnetOffset = -encoderValue;
+            moduleEncoder.getConfigurator().apply(steerEncoderConfig);
             Preferences.setDouble(EncoderPreferenceKey + encoderID, encoderValue);
         }).withName("Calibrate");
     }
@@ -105,7 +111,7 @@ public class SwerveModule extends SubsystemBase{
     }
 
     public double getModuleAngRotations() {
-        return moduleEncoder.getAbsolutePosition().getValueAsDouble() - Preferences.getDouble(EncoderPreferenceKey + encoderID, 0);
+        return moduleEncoder.getAbsolutePosition().getValueAsDouble();
     }
 
     public SwerveModulePosition getModulePosition() {


### PR DESCRIPTION
Needs a test and recalibrate. Some oddities from how drivetrain worked may have affected odometry. Note that all wheels must be aligned with the thick parts all on the same side of the robot (inverted is gone).