### PR TITLE
Higher temporary drive current limits

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -82,6 +82,12 @@ public class Constants {
         public static final double SlowFactorOffset = 1;
 
         public static final double SteerMotorSlewRate = 20;
+        
+        public static final double DriveMotorsLowSupplyCurrentLimit = 40;
+        public static final double DriveMotorsHighSupplyCurrentLimit = 80;
+        public static final double DriveMotorsHighSupplyCurrentSeconds = 2;
+
+        public static final double SteerMotorsSupplyCurrentLimit = 20;
     }
 
     public interface Indexer {

--- a/src/main/java/frc/robot/Subsystems/SwerveModule.java
+++ b/src/main/java/frc/robot/Subsystems/SwerveModule.java
@@ -51,7 +51,9 @@ public class SwerveModule extends SubsystemBase{
         var driveMotorConfig = new TalonFXConfiguration();
         driveMotorConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
         driveMotorConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
-        driveMotorConfig.CurrentLimits.SupplyCurrentLimit = 40;
+        driveMotorConfig.CurrentLimits.SupplyCurrentLimit = Constants.Drivetrain.DriveMotorsHighSupplyCurrentLimit;
+        driveMotorConfig.CurrentLimits.SupplyCurrentLowerLimit = Constants.Drivetrain.DriveMotorsLowSupplyCurrentLimit;
+        driveMotorConfig.CurrentLimits.SupplyCurrentLowerTime = Constants.Drivetrain.DriveMotorsHighSupplyCurrentSeconds;
         driveMotorConfig.Feedback.SensorToMechanismRatio = 1/DRIVE_POSITION_CONVERSION;
         driveMotorConfig.MotorOutput.Inverted = InvertedValue.CounterClockwise_Positive;
         driveMotor.getConfigurator().apply(driveMotorConfig);
@@ -62,7 +64,7 @@ public class SwerveModule extends SubsystemBase{
         var steerMotorConfig = new TalonFXConfiguration();
         steerMotorConfig.MotorOutput.NeutralMode = NeutralModeValue.Brake;
         steerMotorConfig.CurrentLimits.SupplyCurrentLimitEnable = true;
-        steerMotorConfig.CurrentLimits.SupplyCurrentLimit = 20;
+        steerMotorConfig.CurrentLimits.SupplyCurrentLimit = Constants.Drivetrain.SteerMotorsSupplyCurrentLimit;
         steerMotor.getConfigurator().apply(steerMotorConfig);
         
         // module encoder


### PR DESCRIPTION
Allowed for two seconds of 80a current draw for drive motors before dropping back to 40a.